### PR TITLE
In case progress request results in http error, clear the timer and repo...

### DIFF
--- a/jquery.uploadProgress.js
+++ b/jquery.uploadProgress.js
@@ -116,6 +116,11 @@ jQuery.uploadProgress = function(e, options) {
         // Null/false/empty response, assume we're out of process
         options.success(upload);
       }
+    },
+    error: function(upload) {
+      window.clearTimeout(options.timer);
+      options.complete(upload);
+      options.error(upload);
     }
   });
 };


### PR DESCRIPTION
Hey,

in case of http error upload progress keeps retrying the server which may result in flooding the server with requests. It's visible especially in ajax-rich apps when I submit without reloading the page - after multiple submissions and errors on server-side you will get multiple requests per second that have no chance of completion.

Cheers,
TOmasz
